### PR TITLE
Enhance plant lifecycle management and CLI commands in GitForest

### DIFF
--- a/src/GitForest.Cli/Commands/PlantCommand.cs
+++ b/src/GitForest.Cli/Commands/PlantCommand.cs
@@ -20,75 +20,39 @@ public static class PlantCommand
             var forestDir = ForestStore.GetForestDir(ForestStore.DefaultForestDirName);
             try
             {
-                var plants = ForestStore.ListPlants(forestDir, statusFilter: null, planFilter: null);
-                var matches = FindMatches(plants, selector);
-
-                if (matches.Count == 1)
-                {
-                    var plant = matches[0];
-                    if (output.Json)
-                    {
-                        output.WriteJson(new
-                        {
-                            plant = new
-                            {
-                                key = plant.Key,
-                                status = plant.Status,
-                                title = plant.Title,
-                                planId = plant.PlanId,
-                                plannerId = plant.PlannerId,
-                                planters = plant.AssignedPlanters.ToArray()
-                            }
-                        });
-                    }
-                    else
-                    {
-                        var plantersText = plant.AssignedPlanters.Count == 0 ? "-" : string.Join(", ", plant.AssignedPlanters);
-                        output.WriteLine($"Key: {plant.Key}");
-                        output.WriteLine($"Status: {plant.Status}");
-                        output.WriteLine($"Title: {plant.Title}");
-                        output.WriteLine($"Plan: {plant.PlanId}");
-                        output.WriteLine($"Planner: {plant.PlannerId ?? "-"}");
-                        output.WriteLine($"Planters: {plantersText}");
-                    }
-
-                    context.ExitCode = ExitCodes.Success;
-                    return;
-                }
-
-                if (matches.Count == 0)
-                {
-                    if (output.Json)
-                    {
-                        output.WriteJsonError(code: "plant_not_found", message: "Plant not found", details: new { selector });
-                    }
-                    else
-                    {
-                        output.WriteErrorLine($"Plant '{selector}': not found");
-                    }
-
-                    context.ExitCode = ExitCodes.PlantNotFoundOrAmbiguous;
-                    return;
-                }
-
-                // Ambiguous selector.
+                var plant = ForestStore.ResolvePlant(forestDir, selector);
                 if (output.Json)
                 {
-                    output.WriteJsonError(
-                        code: "plant_ambiguous",
-                        message: "Plant selector is ambiguous",
-                        details: new { selector, matches = matches.Select(p => p.Key).ToArray() });
+                    output.WriteJson(new
+                    {
+                        plant = new
+                        {
+                            key = plant.Key,
+                            status = plant.Status,
+                            title = plant.Title,
+                            planId = plant.PlanId,
+                            plannerId = plant.PlannerId,
+                            planters = plant.AssignedPlanters.ToArray(),
+                            branches = plant.Branches.ToArray(),
+                            createdAt = plant.CreatedAt,
+                            updatedAt = plant.UpdatedAt
+                        }
+                    });
                 }
                 else
                 {
-                    output.WriteErrorLine($"Plant '{selector}': ambiguous; matched {matches.Count} plants:");
-                    foreach (var key in matches.Select(p => p.Key).OrderBy(x => x, StringComparer.OrdinalIgnoreCase))
-                    {
-                        output.WriteErrorLine($"- {key}");
-                    }
+                    var plantersText = plant.AssignedPlanters.Count == 0 ? "-" : string.Join(", ", plant.AssignedPlanters);
+                    var branchesText = plant.Branches.Count == 0 ? "-" : string.Join(", ", plant.Branches);
+                    output.WriteLine($"Key: {plant.Key}");
+                    output.WriteLine($"Status: {plant.Status}");
+                    output.WriteLine($"Title: {plant.Title}");
+                    output.WriteLine($"Plan: {plant.PlanId}");
+                    output.WriteLine($"Planner: {plant.PlannerId ?? "-"}");
+                    output.WriteLine($"Planters: {plantersText}");
+                    output.WriteLine($"Branches: {branchesText}");
                 }
 
-                context.ExitCode = ExitCodes.PlantNotFoundOrAmbiguous;
+                context.ExitCode = ExitCodes.Success;
             }
             catch (ForestStore.ForestNotInitializedException)
             {
@@ -105,91 +69,471 @@ public static class PlantCommand
 
                 context.ExitCode = ExitCodes.PlantNotFoundOrAmbiguous;
             }
+            catch (ForestStore.PlantNotFoundException)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "plant_not_found", message: "Plant not found", details: new { selector });
+                }
+                else
+                {
+                    output.WriteErrorLine($"Plant '{selector}': not found");
+                }
+
+                context.ExitCode = ExitCodes.PlantNotFoundOrAmbiguous;
+            }
+            catch (ForestStore.PlantAmbiguousSelectorException ex)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(
+                        code: "plant_ambiguous",
+                        message: "Plant selector is ambiguous",
+                        details: new { selector = ex.Selector, matches = ex.Matches });
+                }
+                else
+                {
+                    output.WriteErrorLine($"Plant '{ex.Selector}': ambiguous; matched {ex.Matches.Length} plants:");
+                    foreach (var key in ex.Matches.OrderBy(x => x, StringComparer.OrdinalIgnoreCase))
+                    {
+                        output.WriteErrorLine($"- {key}");
+                    }
+                }
+
+                context.ExitCode = ExitCodes.PlantNotFoundOrAmbiguous;
+            }
+        });
+
+        var dryRunOption = new Option<bool>("--dry-run", "Show what would be done without applying");
+
+        var assignCommand = new Command("assign", "Assign a planter to this plant");
+        var planterIdArg = new Argument<string>("planter-id", "Planter identifier");
+        assignCommand.AddArgument(planterIdArg);
+        assignCommand.AddOption(dryRunOption);
+        assignCommand.SetHandler((InvocationContext context) =>
+        {
+            var output = context.GetOutput(cliOptions);
+            var selector = context.ParseResult.GetValueForArgument(selectorArg);
+            var planterId = context.ParseResult.GetValueForArgument(planterIdArg);
+            var dryRun = context.ParseResult.GetValueForOption(dryRunOption);
+
+            var forestDir = ForestStore.GetForestDir(ForestStore.DefaultForestDirName);
+            try
+            {
+                var updated = ForestStore.UpdatePlant(forestDir, selector, plant =>
+                {
+                    var normalizedPlanterId = (planterId ?? string.Empty).Trim();
+                    if (normalizedPlanterId.Length == 0)
+                    {
+                        return plant;
+                    }
+
+                    var planters = (plant.AssignedPlanters ?? Array.Empty<string>()).ToList();
+                    if (!planters.Any(p => string.Equals(p, normalizedPlanterId, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        planters.Add(normalizedPlanterId);
+                    }
+
+                    var status = plant.Status;
+                    if (string.Equals(status, "planned", StringComparison.OrdinalIgnoreCase))
+                    {
+                        status = "planted";
+                    }
+
+                    return plant with { AssignedPlanters = planters, Status = status };
+                }, dryRun);
+
+                if (output.Json)
+                {
+                    output.WriteJson(new { status = "assigned", dryRun, plantKey = updated.Key, planterId = planterId.Trim(), plantStatus = updated.Status });
+                }
+                else
+                {
+                    output.WriteLine(dryRun
+                        ? $"Would assign planter '{planterId}' to plant '{updated.Key}'"
+                        : $"Assigned planter '{planterId}' to plant '{updated.Key}'");
+                }
+
+                context.ExitCode = ExitCodes.Success;
+            }
+            catch (ForestStore.ForestNotInitializedException)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "forest_not_initialized", message: "Forest not initialized");
+                }
+                else
+                {
+                    output.WriteErrorLine("Error: forest not initialized");
+                }
+
+                context.ExitCode = ExitCodes.ForestNotInitialized;
+            }
+            catch (ForestStore.PlantNotFoundException)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "plant_not_found", message: "Plant not found", details: new { selector });
+                }
+                else
+                {
+                    output.WriteErrorLine($"Plant '{selector}': not found");
+                }
+
+                context.ExitCode = ExitCodes.PlantNotFoundOrAmbiguous;
+            }
+            catch (ForestStore.PlantAmbiguousSelectorException ex)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "plant_ambiguous", message: "Plant selector is ambiguous", details: new { selector = ex.Selector, matches = ex.Matches });
+                }
+                else
+                {
+                    output.WriteErrorLine($"Plant '{ex.Selector}': ambiguous; matched {ex.Matches.Length} plants");
+                }
+
+                context.ExitCode = ExitCodes.PlantNotFoundOrAmbiguous;
+            }
+        });
+
+        var unassignCommand = new Command("unassign", "Unassign a planter from this plant");
+        unassignCommand.AddArgument(planterIdArg);
+        unassignCommand.AddOption(dryRunOption);
+        unassignCommand.SetHandler((InvocationContext context) =>
+        {
+            var output = context.GetOutput(cliOptions);
+            var selector = context.ParseResult.GetValueForArgument(selectorArg);
+            var planterId = context.ParseResult.GetValueForArgument(planterIdArg);
+            var dryRun = context.ParseResult.GetValueForOption(dryRunOption);
+
+            var forestDir = ForestStore.GetForestDir(ForestStore.DefaultForestDirName);
+            try
+            {
+                var updated = ForestStore.UpdatePlant(forestDir, selector, plant =>
+                {
+                    var normalizedPlanterId = (planterId ?? string.Empty).Trim();
+                    var planters = (plant.AssignedPlanters ?? Array.Empty<string>())
+                        .Where(p => !string.Equals(p, normalizedPlanterId, StringComparison.OrdinalIgnoreCase))
+                        .ToList();
+                    return plant with { AssignedPlanters = planters };
+                }, dryRun);
+
+                if (output.Json)
+                {
+                    output.WriteJson(new { status = "unassigned", dryRun, plantKey = updated.Key, planterId = planterId.Trim(), plantStatus = updated.Status });
+                }
+                else
+                {
+                    output.WriteLine(dryRun
+                        ? $"Would unassign planter '{planterId}' from plant '{updated.Key}'"
+                        : $"Unassigned planter '{planterId}' from plant '{updated.Key}'");
+                }
+
+                context.ExitCode = ExitCodes.Success;
+            }
+            catch (ForestStore.ForestNotInitializedException)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "forest_not_initialized", message: "Forest not initialized");
+                }
+                else
+                {
+                    output.WriteErrorLine("Error: forest not initialized");
+                }
+
+                context.ExitCode = ExitCodes.ForestNotInitialized;
+            }
+            catch (ForestStore.PlantNotFoundException)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "plant_not_found", message: "Plant not found", details: new { selector });
+                }
+                else
+                {
+                    output.WriteErrorLine($"Plant '{selector}': not found");
+                }
+
+                context.ExitCode = ExitCodes.PlantNotFoundOrAmbiguous;
+            }
+            catch (ForestStore.PlantAmbiguousSelectorException ex)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "plant_ambiguous", message: "Plant selector is ambiguous", details: new { selector = ex.Selector, matches = ex.Matches });
+                }
+                else
+                {
+                    output.WriteErrorLine($"Plant '{ex.Selector}': ambiguous; matched {ex.Matches.Length} plants");
+                }
+
+                context.ExitCode = ExitCodes.PlantNotFoundOrAmbiguous;
+            }
+        });
+
+        var branchesCommand = new Command("branches", "Manage plant branches");
+        var branchesListCommand = new Command("list", "List branches recorded for this plant");
+        branchesListCommand.SetHandler((InvocationContext context) =>
+        {
+            var output = context.GetOutput(cliOptions);
+            var selector = context.ParseResult.GetValueForArgument(selectorArg);
+            var forestDir = ForestStore.GetForestDir(ForestStore.DefaultForestDirName);
+
+            try
+            {
+                var plant = ForestStore.ResolvePlant(forestDir, selector);
+                var branches = plant.Branches ?? Array.Empty<string>();
+
+                if (output.Json)
+                {
+                    output.WriteJson(new { plantKey = plant.Key, branches = branches.ToArray() });
+                }
+                else
+                {
+                    if (branches.Count == 0)
+                    {
+                        output.WriteLine("No branches recorded");
+                    }
+                    else
+                    {
+                        foreach (var br in branches)
+                        {
+                            output.WriteLine(br);
+                        }
+                    }
+                }
+
+                context.ExitCode = ExitCodes.Success;
+            }
+            catch (ForestStore.ForestNotInitializedException)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "forest_not_initialized", message: "Forest not initialized");
+                }
+                else
+                {
+                    output.WriteErrorLine("Error: forest not initialized");
+                }
+
+                context.ExitCode = ExitCodes.ForestNotInitialized;
+            }
+            catch (ForestStore.PlantNotFoundException)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "plant_not_found", message: "Plant not found", details: new { selector });
+                }
+                else
+                {
+                    output.WriteErrorLine($"Plant '{selector}': not found");
+                }
+
+                context.ExitCode = ExitCodes.PlantNotFoundOrAmbiguous;
+            }
+            catch (ForestStore.PlantAmbiguousSelectorException ex)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "plant_ambiguous", message: "Plant selector is ambiguous", details: new { selector = ex.Selector, matches = ex.Matches });
+                }
+                else
+                {
+                    output.WriteErrorLine($"Plant '{ex.Selector}': ambiguous; matched {ex.Matches.Length} plants");
+                }
+
+                context.ExitCode = ExitCodes.PlantNotFoundOrAmbiguous;
+            }
+        });
+        branchesCommand.AddCommand(branchesListCommand);
+
+        var forceOption = new Option<bool>("--force", "Force state transition even if current status is unexpected");
+
+        var harvestCommand = new Command("harvest", "Mark plant as harvested");
+        harvestCommand.AddOption(forceOption);
+        harvestCommand.AddOption(dryRunOption);
+        harvestCommand.SetHandler((InvocationContext context) =>
+        {
+            var output = context.GetOutput(cliOptions);
+            var selector = context.ParseResult.GetValueForArgument(selectorArg);
+            var force = context.ParseResult.GetValueForOption(forceOption);
+            var dryRun = context.ParseResult.GetValueForOption(dryRunOption);
+            var forestDir = ForestStore.GetForestDir(ForestStore.DefaultForestDirName);
+
+            try
+            {
+                var updated = ForestStore.UpdatePlant(forestDir, selector, plant =>
+                {
+                    if (!force && !string.Equals(plant.Status, "harvestable", StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new InvalidOperationException($"Plant is not harvestable (status={plant.Status}).");
+                    }
+
+                    return plant with { Status = "harvested" };
+                }, dryRun);
+
+                if (output.Json)
+                {
+                    output.WriteJson(new { status = "harvested", dryRun, plantKey = updated.Key });
+                }
+                else
+                {
+                    output.WriteLine(dryRun ? $"Would harvest '{updated.Key}'" : $"Harvested '{updated.Key}'");
+                }
+
+                context.ExitCode = ExitCodes.Success;
+            }
+            catch (InvalidOperationException ex)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "invalid_state", message: ex.Message, details: new { selector });
+                }
+                else
+                {
+                    output.WriteErrorLine($"Error: {ex.Message}");
+                }
+
+                context.ExitCode = ExitCodes.InvalidArguments;
+            }
+            catch (ForestStore.ForestNotInitializedException)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "forest_not_initialized", message: "Forest not initialized");
+                }
+                else
+                {
+                    output.WriteErrorLine("Error: forest not initialized");
+                }
+
+                context.ExitCode = ExitCodes.ForestNotInitialized;
+            }
+            catch (ForestStore.PlantNotFoundException)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "plant_not_found", message: "Plant not found", details: new { selector });
+                }
+                else
+                {
+                    output.WriteErrorLine($"Plant '{selector}': not found");
+                }
+
+                context.ExitCode = ExitCodes.PlantNotFoundOrAmbiguous;
+            }
+            catch (ForestStore.PlantAmbiguousSelectorException ex)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "plant_ambiguous", message: "Plant selector is ambiguous", details: new { selector = ex.Selector, matches = ex.Matches });
+                }
+                else
+                {
+                    output.WriteErrorLine($"Plant '{ex.Selector}': ambiguous; matched {ex.Matches.Length} plants");
+                }
+
+                context.ExitCode = ExitCodes.PlantNotFoundOrAmbiguous;
+            }
+        });
+
+        var archiveCommand = new Command("archive", "Archive plant");
+        archiveCommand.AddOption(forceOption);
+        archiveCommand.AddOption(dryRunOption);
+        archiveCommand.SetHandler((InvocationContext context) =>
+        {
+            var output = context.GetOutput(cliOptions);
+            var selector = context.ParseResult.GetValueForArgument(selectorArg);
+            var force = context.ParseResult.GetValueForOption(forceOption);
+            var dryRun = context.ParseResult.GetValueForOption(dryRunOption);
+            var forestDir = ForestStore.GetForestDir(ForestStore.DefaultForestDirName);
+
+            try
+            {
+                var updated = ForestStore.UpdatePlant(forestDir, selector, plant =>
+                {
+                    if (!force && !string.Equals(plant.Status, "harvested", StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new InvalidOperationException($"Plant is not harvested (status={plant.Status}).");
+                    }
+
+                    return plant with { Status = "archived" };
+                }, dryRun);
+
+                if (output.Json)
+                {
+                    output.WriteJson(new { status = "archived", dryRun, plantKey = updated.Key });
+                }
+                else
+                {
+                    output.WriteLine(dryRun ? $"Would archive '{updated.Key}'" : $"Archived '{updated.Key}'");
+                }
+
+                context.ExitCode = ExitCodes.Success;
+            }
+            catch (InvalidOperationException ex)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "invalid_state", message: ex.Message, details: new { selector });
+                }
+                else
+                {
+                    output.WriteErrorLine($"Error: {ex.Message}");
+                }
+
+                context.ExitCode = ExitCodes.InvalidArguments;
+            }
+            catch (ForestStore.ForestNotInitializedException)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "forest_not_initialized", message: "Forest not initialized");
+                }
+                else
+                {
+                    output.WriteErrorLine("Error: forest not initialized");
+                }
+
+                context.ExitCode = ExitCodes.ForestNotInitialized;
+            }
+            catch (ForestStore.PlantNotFoundException)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "plant_not_found", message: "Plant not found", details: new { selector });
+                }
+                else
+                {
+                    output.WriteErrorLine($"Plant '{selector}': not found");
+                }
+
+                context.ExitCode = ExitCodes.PlantNotFoundOrAmbiguous;
+            }
+            catch (ForestStore.PlantAmbiguousSelectorException ex)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "plant_ambiguous", message: "Plant selector is ambiguous", details: new { selector = ex.Selector, matches = ex.Matches });
+                }
+                else
+                {
+                    output.WriteErrorLine($"Plant '{ex.Selector}': ambiguous; matched {ex.Matches.Length} plants");
+                }
+
+                context.ExitCode = ExitCodes.PlantNotFoundOrAmbiguous;
+            }
         });
 
         plantCommand.AddCommand(showCommand);
+        plantCommand.AddCommand(assignCommand);
+        plantCommand.AddCommand(unassignCommand);
+        plantCommand.AddCommand(branchesCommand);
+        plantCommand.AddCommand(harvestCommand);
+        plantCommand.AddCommand(archiveCommand);
         return plantCommand;
-    }
-
-    private static IReadOnlyList<ForestStore.PlantRecord> FindMatches(IReadOnlyList<ForestStore.PlantRecord> plants, string selector)
-    {
-        var sel = (selector ?? string.Empty).Trim();
-        if (sel.Length == 0 || plants.Count == 0)
-        {
-            return Array.Empty<ForestStore.PlantRecord>();
-        }
-
-        // 1) Exact key match: <plan-id>:<slug>
-        var exact = plants.Where(p => string.Equals(p.Key, sel, StringComparison.OrdinalIgnoreCase)).ToArray();
-        if (exact.Length > 0)
-        {
-            return exact;
-        }
-
-        // 2) Pxx style stable index into ordered list (best-effort; deterministic ordering).
-        if (TryParsePIndex(sel, out var index))
-        {
-            var ordered = plants.OrderBy(p => p.Key, StringComparer.OrdinalIgnoreCase).ToArray();
-            if (index >= 0 && index < ordered.Length)
-            {
-                return new[] { ordered[index] };
-            }
-
-            return Array.Empty<ForestStore.PlantRecord>();
-        }
-
-        // 3) Slug match: match any plant whose key right-side equals selector.
-        var slugMatches = plants.Where(p =>
-        {
-            var key = p.Key ?? string.Empty;
-            var idx = key.IndexOf(':', StringComparison.Ordinal);
-            if (idx < 0 || idx == key.Length - 1)
-            {
-                return false;
-            }
-
-            var slug = key[(idx + 1)..];
-            return string.Equals(slug, sel, StringComparison.OrdinalIgnoreCase);
-        }).ToArray();
-
-        return slugMatches;
-    }
-
-    private static bool TryParsePIndex(string selector, out int index)
-    {
-        // Accept P01, p1, P0003 → 1-based ordinal; convert to 0-based index.
-        index = -1;
-        if (selector.Length < 2)
-        {
-            return false;
-        }
-
-        if (selector[0] != 'p' && selector[0] != 'P')
-        {
-            return false;
-        }
-
-        var digits = selector[1..].Trim();
-        if (digits.Length == 0)
-        {
-            return false;
-        }
-
-        foreach (var ch in digits)
-        {
-            if (!char.IsDigit(ch))
-            {
-                return false;
-            }
-        }
-
-        if (!int.TryParse(digits, out var oneBased) || oneBased <= 0)
-        {
-            return false;
-        }
-
-        index = oneBased - 1;
-        return true;
     }
 }
 

--- a/src/GitForest.Cli/Commands/PlanterCommand.cs
+++ b/src/GitForest.Cli/Commands/PlanterCommand.cs
@@ -1,5 +1,6 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using System.Text;
 
 namespace GitForest.Cli.Commands;
 
@@ -16,23 +17,513 @@ public static class PlanterCommand
         {
             var output = context.GetOutput(cliOptions);
             var planterId = context.ParseResult.GetValueForArgument(planterIdArg);
+            var forestDir = ForestStore.GetForestDir(ForestStore.DefaultForestDirName);
 
-            // TODO: Implement actual planter lookup
-            if (output.Json)
+            try
             {
-                output.WriteJsonError(code: "planter_not_found", message: "Planter not found", details: new { planterId });
-            }
-            else
-            {
-                output.WriteErrorLine($"Planter '{planterId}': not found");
-            }
+                var info = GetPlanterInfo(forestDir, planterId);
+                if (!info.Exists)
+                {
+                    if (output.Json)
+                    {
+                        output.WriteJsonError(code: "planter_not_found", message: "Planter not found", details: new { planterId });
+                    }
+                    else
+                    {
+                        output.WriteErrorLine($"Planter '{planterId}': not found");
+                    }
 
-            context.ExitCode = ExitCodes.PlanterNotFound;
+                    context.ExitCode = ExitCodes.PlanterNotFound;
+                    return;
+                }
+
+                if (output.Json)
+                {
+                    output.WriteJson(new { planter = new { id = info.Id, kind = info.Kind, plans = info.Plans } });
+                }
+                else
+                {
+                    var plansText = info.Plans.Length == 0 ? "-" : string.Join(", ", info.Plans);
+                    output.WriteLine($"Id: {info.Id}");
+                    output.WriteLine($"Kind: {info.Kind}");
+                    output.WriteLine($"Plans: {plansText}");
+                }
+
+                context.ExitCode = ExitCodes.Success;
+            }
+            catch (ForestStore.ForestNotInitializedException)
+            {
+                // For single-planter lookup, treat missing forest as "not found" (keeps CLI usable in fresh repos
+                // and matches the smoke-test contract).
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "planter_not_found", message: "Planter not found", details: new { planterId });
+                }
+                else
+                {
+                    output.WriteErrorLine($"Planter '{planterId}': not found");
+                }
+
+                context.ExitCode = ExitCodes.PlanterNotFound;
+            }
+        });
+
+        var plantCommand = new Command("plant", "Assign + create branch for a plant");
+        var selectorArg = new Argument<string>("selector", "Plant selector (key, slug, or P01)");
+        var branchOption = new Option<string>("--branch", () => "auto", "Branch name to use ('auto' uses a deterministic default)");
+        var yesOption = new Option<bool>("--yes", "Proceed without prompting");
+        var dryRunOption = new Option<bool>("--dry-run", "Show what would be done without applying");
+        plantCommand.AddArgument(selectorArg);
+        plantCommand.AddOption(branchOption);
+        plantCommand.AddOption(yesOption);
+        plantCommand.AddOption(dryRunOption);
+        plantCommand.SetHandler((InvocationContext context) =>
+        {
+            var output = context.GetOutput(cliOptions);
+            var planterId = context.ParseResult.GetValueForArgument(planterIdArg);
+            var selector = context.ParseResult.GetValueForArgument(selectorArg);
+            var branch = context.ParseResult.GetValueForOption(branchOption);
+            var yes = context.ParseResult.GetValueForOption(yesOption);
+            var dryRun = context.ParseResult.GetValueForOption(dryRunOption);
+
+            var forestDir = ForestStore.GetForestDir(ForestStore.DefaultForestDirName);
+
+            try
+            {
+                var info = GetPlanterInfo(forestDir, planterId);
+                if (!info.Exists)
+                {
+                    if (output.Json)
+                    {
+                        output.WriteJsonError(code: "planter_not_found", message: "Planter not found", details: new { planterId });
+                    }
+                    else
+                    {
+                        output.WriteErrorLine($"Planter '{planterId}': not found");
+                    }
+
+                    context.ExitCode = ExitCodes.PlanterNotFound;
+                    return;
+                }
+
+                var plant = ForestStore.ResolvePlant(forestDir, selector);
+                var branchName = ComputeBranchName(planterId, plant.Key, branch);
+
+                var updated = ForestStore.UpdatePlant(forestDir, selector, p =>
+                {
+                    var planters = (p.AssignedPlanters ?? Array.Empty<string>()).ToList();
+                    if (!planters.Any(x => string.Equals(x, planterId, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        planters.Add(planterId);
+                    }
+
+                    var branches = (p.Branches ?? Array.Empty<string>()).ToList();
+                    if (!branches.Any(x => string.Equals(x, branchName, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        branches.Add(branchName);
+                    }
+
+                    var status = p.Status;
+                    if (string.Equals(status, "planned", StringComparison.OrdinalIgnoreCase))
+                    {
+                        status = "planted";
+                    }
+
+                    return p with { AssignedPlanters = planters, Branches = branches, Status = status };
+                }, dryRun);
+
+                if (!dryRun)
+                {
+                    if (!yes)
+                    {
+                        if (output.Json)
+                        {
+                            output.WriteJsonError(code: "confirmation_required", message: "Use --yes to create/check out a git branch.", details: new { branch = branchName });
+                        }
+                        else
+                        {
+                            output.WriteErrorLine("Error: confirmation required. Re-run with --yes.");
+                        }
+
+                        context.ExitCode = ExitCodes.InvalidArguments;
+                        return;
+                    }
+
+                    var repoRoot = GitRunner.GetRepoRoot();
+                    GitRunner.CheckoutBranch(branchName, createIfMissing: true, workingDirectory: repoRoot);
+                }
+
+                if (output.Json)
+                {
+                    output.WriteJson(new { status = "planted", dryRun, planterId, plantKey = updated.Key, branch = branchName });
+                }
+                else
+                {
+                    output.WriteLine(dryRun
+                        ? $"Would plant '{updated.Key}' with planter '{planterId}' on branch '{branchName}'"
+                        : $"Planted '{updated.Key}' with planter '{planterId}' on branch '{branchName}'");
+                }
+
+                context.ExitCode = ExitCodes.Success;
+            }
+            catch (ForestStore.ForestNotInitializedException)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "forest_not_initialized", message: "Forest not initialized");
+                }
+                else
+                {
+                    output.WriteErrorLine("Error: forest not initialized");
+                }
+
+                context.ExitCode = ExitCodes.ForestNotInitialized;
+            }
+            catch (ForestStore.PlantNotFoundException)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "plant_not_found", message: "Plant not found", details: new { selector });
+                }
+                else
+                {
+                    output.WriteErrorLine($"Plant '{selector}': not found");
+                }
+
+                context.ExitCode = ExitCodes.PlantNotFoundOrAmbiguous;
+            }
+            catch (ForestStore.PlantAmbiguousSelectorException ex)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "plant_ambiguous", message: "Plant selector is ambiguous", details: new { selector = ex.Selector, matches = ex.Matches });
+                }
+                else
+                {
+                    output.WriteErrorLine($"Plant '{ex.Selector}': ambiguous; matched {ex.Matches.Length} plants");
+                }
+
+                context.ExitCode = ExitCodes.PlantNotFoundOrAmbiguous;
+            }
+            catch (GitRunner.GitRunnerException ex)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "git_failed", message: ex.Message, details: new { exitCode = ex.ExitCode, stdout = ex.StdOut, stderr = ex.StdErr });
+                }
+                else
+                {
+                    output.WriteErrorLine($"Error: {ex.Message}");
+                    if (!string.IsNullOrWhiteSpace(ex.StdErr))
+                    {
+                        output.WriteErrorLine(ex.StdErr.Trim());
+                    }
+                }
+
+                context.ExitCode = ExitCodes.GitOperationFailed;
+            }
+        });
+
+        var growCommand = new Command("grow", "Grow a plant (propose or apply changes)");
+        var modeOption = new Option<string>("--mode", () => "apply", "Mode: propose|apply");
+        growCommand.AddArgument(selectorArg);
+        growCommand.AddOption(modeOption);
+        growCommand.AddOption(dryRunOption);
+        growCommand.SetHandler((InvocationContext context) =>
+        {
+            var output = context.GetOutput(cliOptions);
+            var planterId = context.ParseResult.GetValueForArgument(planterIdArg);
+            var selector = context.ParseResult.GetValueForArgument(selectorArg);
+            var mode = (context.ParseResult.GetValueForOption(modeOption) ?? "apply").Trim();
+            var dryRun = context.ParseResult.GetValueForOption(dryRunOption);
+            var forestDir = ForestStore.GetForestDir(ForestStore.DefaultForestDirName);
+
+            try
+            {
+                var info = GetPlanterInfo(forestDir, planterId);
+                if (!info.Exists)
+                {
+                    if (output.Json)
+                    {
+                        output.WriteJsonError(code: "planter_not_found", message: "Planter not found", details: new { planterId });
+                    }
+                    else
+                    {
+                        output.WriteErrorLine($"Planter '{planterId}': not found");
+                    }
+
+                    context.ExitCode = ExitCodes.PlanterNotFound;
+                    return;
+                }
+
+                if (!string.Equals(mode, "apply", StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(mode, "propose", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (output.Json)
+                    {
+                        output.WriteJsonError(code: "invalid_arguments", message: "Invalid --mode. Expected: propose|apply", details: new { mode });
+                    }
+                    else
+                    {
+                        output.WriteErrorLine("Error: invalid --mode. Expected: propose|apply");
+                    }
+
+                    context.ExitCode = ExitCodes.InvalidArguments;
+                    return;
+                }
+
+                var plant = ForestStore.ResolvePlant(forestDir, selector);
+                var branchName = plant.Branches.FirstOrDefault();
+                if (string.IsNullOrWhiteSpace(branchName))
+                {
+                    branchName = ComputeBranchName(planterId, plant.Key, "auto");
+                }
+
+                // Mark growing (apply mode only) before we attempt the work.
+                if (!dryRun && string.Equals(mode, "apply", StringComparison.OrdinalIgnoreCase))
+                {
+                    _ = ForestStore.UpdatePlant(forestDir, selector, p =>
+                    {
+                        var planters = (p.AssignedPlanters ?? Array.Empty<string>()).ToList();
+                        if (!planters.Any(x => string.Equals(x, planterId, StringComparison.OrdinalIgnoreCase)))
+                        {
+                            planters.Add(planterId);
+                        }
+
+                        var branches = (p.Branches ?? Array.Empty<string>()).ToList();
+                        if (!branches.Any(x => string.Equals(x, branchName, StringComparison.OrdinalIgnoreCase)))
+                        {
+                            branches.Add(branchName);
+                        }
+
+                        return p with { AssignedPlanters = planters, Branches = branches, Status = "growing" };
+                    }, dryRun: false);
+                }
+
+                if (string.Equals(mode, "apply", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (!dryRun)
+                    {
+                        var repoRoot = GitRunner.GetRepoRoot();
+                        GitRunner.CheckoutBranch(branchName, createIfMissing: true, workingDirectory: repoRoot);
+
+                        ApplyDeterministicGrowth(repoRoot, plantKey: plant.Key, planterId: planterId);
+
+                        if (GitRunner.HasUncommittedChanges(repoRoot))
+                        {
+                            GitRunner.AddAll(repoRoot);
+                            GitRunner.Commit($"git-forest: grow {plant.Key}", repoRoot);
+                        }
+                    }
+                }
+
+                var final = ForestStore.UpdatePlant(forestDir, selector, p =>
+                {
+                    var planters = (p.AssignedPlanters ?? Array.Empty<string>()).ToList();
+                    if (!planters.Any(x => string.Equals(x, planterId, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        planters.Add(planterId);
+                    }
+
+                    var branches = (p.Branches ?? Array.Empty<string>()).ToList();
+                    if (!branches.Any(x => string.Equals(x, branchName, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        branches.Add(branchName);
+                    }
+
+                    return p with
+                    {
+                        AssignedPlanters = planters,
+                        Branches = branches,
+                        Status = "harvestable"
+                    };
+                }, dryRun);
+
+                if (output.Json)
+                {
+                    output.WriteJson(new { status = "harvestable", dryRun, mode, planterId, plantKey = final.Key, branch = branchName });
+                }
+                else
+                {
+                    output.WriteLine(dryRun
+                        ? $"Would grow '{final.Key}' (mode={mode})"
+                        : $"Grew '{final.Key}' (mode={mode}) → harvestable");
+                }
+
+                context.ExitCode = ExitCodes.Success;
+            }
+            catch (ForestStore.ForestNotInitializedException)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "forest_not_initialized", message: "Forest not initialized");
+                }
+                else
+                {
+                    output.WriteErrorLine("Error: forest not initialized");
+                }
+
+                context.ExitCode = ExitCodes.ForestNotInitialized;
+            }
+            catch (ForestStore.PlantNotFoundException)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "plant_not_found", message: "Plant not found", details: new { selector });
+                }
+                else
+                {
+                    output.WriteErrorLine($"Plant '{selector}': not found");
+                }
+
+                context.ExitCode = ExitCodes.PlantNotFoundOrAmbiguous;
+            }
+            catch (ForestStore.PlantAmbiguousSelectorException ex)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "plant_ambiguous", message: "Plant selector is ambiguous", details: new { selector = ex.Selector, matches = ex.Matches });
+                }
+                else
+                {
+                    output.WriteErrorLine($"Plant '{ex.Selector}': ambiguous; matched {ex.Matches.Length} plants");
+                }
+
+                context.ExitCode = ExitCodes.PlantNotFoundOrAmbiguous;
+            }
+            catch (GitRunner.GitRunnerException ex)
+            {
+                if (output.Json)
+                {
+                    output.WriteJsonError(code: "git_failed", message: ex.Message, details: new { exitCode = ex.ExitCode, stdout = ex.StdOut, stderr = ex.StdErr });
+                }
+                else
+                {
+                    output.WriteErrorLine($"Error: {ex.Message}");
+                    if (!string.IsNullOrWhiteSpace(ex.StdErr))
+                    {
+                        output.WriteErrorLine(ex.StdErr.Trim());
+                    }
+                }
+
+                context.ExitCode = ExitCodes.GitOperationFailed;
+            }
         });
 
         planterCommand.AddCommand(showCommand);
+        planterCommand.AddCommand(plantCommand);
+        planterCommand.AddCommand(growCommand);
         return planterCommand;
     }
+
+    private static (bool Exists, string Id, string Kind, string[] Plans) GetPlanterInfo(string forestDir, string planterId)
+    {
+        var id = (planterId ?? string.Empty).Trim();
+        if (id.Length == 0)
+        {
+            return (false, string.Empty, string.Empty, Array.Empty<string>());
+        }
+
+        var plans = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var installedPlans = ForestStore.ListPlans(forestDir);
+        foreach (var installed in installedPlans)
+        {
+            if (string.IsNullOrWhiteSpace(installed.Id))
+            {
+                continue;
+            }
+
+            var planId = installed.Id.Trim();
+            var planYamlPath = Path.Combine(forestDir, "plans", planId, "plan.yaml");
+            if (!File.Exists(planYamlPath))
+            {
+                continue;
+            }
+
+            try
+            {
+                var yaml = File.ReadAllText(planYamlPath);
+                var parsed = PlanYamlLite.Parse(yaml);
+                foreach (var raw in parsed.Planters ?? Array.Empty<string>())
+                {
+                    if (string.Equals((raw ?? string.Empty).Trim(), id, StringComparison.OrdinalIgnoreCase))
+                    {
+                        plans.Add(planId);
+                    }
+                }
+            }
+            catch
+            {
+                // best-effort
+            }
+        }
+
+        var isCustom = Directory.Exists(Path.Combine(forestDir, "planters", id));
+        var isBuiltin = plans.Count > 0;
+        var exists = isBuiltin || isCustom;
+        var kind = isBuiltin ? "builtin" : (isCustom ? "custom" : string.Empty);
+        return (exists, id, kind, plans.OrderBy(x => x, StringComparer.OrdinalIgnoreCase).ToArray());
+    }
+
+    private static string ComputeBranchName(string planterId, string plantKey, string? branchOption)
+    {
+        var opt = (branchOption ?? "auto").Trim();
+        if (!string.Equals(opt, "auto", StringComparison.OrdinalIgnoreCase) && opt.Length > 0)
+        {
+            return NormalizeBranchName(opt);
+        }
+
+        var (planId, slug) = ForestStore.SplitPlantKey(plantKey);
+        return NormalizeBranchName($"{planterId}/{planId}__{slug}");
+    }
+
+    private static string NormalizeBranchName(string input)
+    {
+        var trimmed = (input ?? string.Empty).Trim();
+        if (trimmed.Length == 0)
+        {
+            return "git-forest/untitled";
+        }
+
+        var sb = new StringBuilder(trimmed.Length);
+        var lastWasDash = false;
+        foreach (var ch in trimmed)
+        {
+            if (char.IsLetterOrDigit(ch) || ch is '/' or '-' or '_' or '.')
+            {
+                sb.Append(ch);
+                lastWasDash = false;
+                continue;
+            }
+
+            if (!lastWasDash)
+            {
+                sb.Append('-');
+                lastWasDash = true;
+            }
+        }
+
+        var normalized = sb.ToString().Trim('-');
+        return normalized.Length == 0 ? "git-forest/untitled" : normalized;
+    }
+
+    private static void ApplyDeterministicGrowth(string repoRoot, string plantKey, string planterId)
+    {
+        // MVP: a deterministic, safe change that works in any repo. Keep it small and idempotent.
+        var readmePath = Path.Combine(repoRoot, "README.md");
+        if (!File.Exists(readmePath))
+        {
+            File.WriteAllText(readmePath, "# Repository\n", Encoding.UTF8);
+        }
+
+        var marker = $"<!-- git-forest: {plantKey} (planter={planterId}) -->";
+        var content = File.ReadAllText(readmePath, Encoding.UTF8);
+        if (content.Contains(marker, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var updated = content.TrimEnd() + Environment.NewLine + Environment.NewLine + marker + Environment.NewLine;
+        File.WriteAllText(readmePath, updated, Encoding.UTF8);
+    }
 }
-
-

--- a/src/GitForest.Cli/GitRunner.cs
+++ b/src/GitForest.Cli/GitRunner.cs
@@ -1,0 +1,155 @@
+using System.Diagnostics;
+using System.Text;
+
+namespace GitForest.Cli;
+
+internal static class GitRunner
+{
+    public sealed record GitResult(int ExitCode, string StdOut, string StdErr);
+
+    public static GitResult Run(IReadOnlyList<string> arguments, string? workingDirectory = null)
+    {
+        if (arguments is null)
+        {
+            throw new ArgumentNullException(nameof(arguments));
+        }
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = string.IsNullOrWhiteSpace(workingDirectory) ? Environment.CurrentDirectory : workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        // Avoid interactive prompts in automation contexts.
+        startInfo.Environment["GIT_TERMINAL_PROMPT"] = "0";
+
+        foreach (var arg in arguments)
+        {
+            startInfo.ArgumentList.Add(arg);
+        }
+
+        using var process = new Process { StartInfo = startInfo };
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data is not null)
+            {
+                stdout.AppendLine(e.Data);
+            }
+        };
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data is not null)
+            {
+                stderr.AppendLine(e.Data);
+            }
+        };
+
+        if (!process.Start())
+        {
+            throw new InvalidOperationException("Failed to start git process.");
+        }
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        process.WaitForExit();
+
+        return new GitResult(process.ExitCode, stdout.ToString(), stderr.ToString());
+    }
+
+    public static GitResult RunOrThrow(IReadOnlyList<string> arguments, string? workingDirectory = null)
+    {
+        var result = Run(arguments, workingDirectory);
+        if (result.ExitCode != 0)
+        {
+            throw new GitRunnerException(arguments, result.ExitCode, result.StdOut, result.StdErr);
+        }
+
+        return result;
+    }
+
+    public static bool HasUncommittedChanges(string? workingDirectory = null)
+    {
+        var res = Run(["status", "--porcelain"], workingDirectory);
+        return res.ExitCode == 0 && !string.IsNullOrWhiteSpace(res.StdOut);
+    }
+
+    public static string GetRepoRoot(string? workingDirectory = null)
+    {
+        var res = RunOrThrow(["rev-parse", "--show-toplevel"], workingDirectory);
+        return (res.StdOut ?? string.Empty).Trim();
+    }
+
+    public static bool BranchExists(string branchName, string? workingDirectory = null)
+    {
+        if (string.IsNullOrWhiteSpace(branchName))
+        {
+            return false;
+        }
+
+        var res = Run(["show-ref", "--verify", $"refs/heads/{branchName.Trim()}"], workingDirectory);
+        return res.ExitCode == 0;
+    }
+
+    public static void CheckoutBranch(string branchName, bool createIfMissing, string? workingDirectory = null)
+    {
+        var name = (branchName ?? string.Empty).Trim();
+        if (name.Length == 0)
+        {
+            throw new ArgumentException("Branch name must be provided.", nameof(branchName));
+        }
+
+        if (BranchExists(name, workingDirectory))
+        {
+            RunOrThrow(["checkout", name], workingDirectory);
+            return;
+        }
+
+        if (!createIfMissing)
+        {
+            throw new InvalidOperationException($"Branch does not exist: {name}");
+        }
+
+        RunOrThrow(["checkout", "-b", name], workingDirectory);
+    }
+
+    public static void AddAll(string? workingDirectory = null)
+    {
+        RunOrThrow(["add", "-A"], workingDirectory);
+    }
+
+    public static void Commit(string message, string? workingDirectory = null)
+    {
+        var msg = (message ?? string.Empty).Trim();
+        if (msg.Length == 0)
+        {
+            throw new ArgumentException("Commit message must be provided.", nameof(message));
+        }
+
+        RunOrThrow(["commit", "-m", msg], workingDirectory);
+    }
+
+    public sealed class GitRunnerException : Exception
+    {
+        public IReadOnlyList<string> Arguments { get; }
+        public int ExitCode { get; }
+        public string StdOut { get; }
+        public string StdErr { get; }
+
+        public GitRunnerException(IReadOnlyList<string> arguments, int exitCode, string stdOut, string stdErr)
+            : base($"git {string.Join(' ', arguments)} failed with exit code {exitCode}")
+        {
+            Arguments = arguments;
+            ExitCode = exitCode;
+            StdOut = stdOut;
+            StdErr = stdErr;
+        }
+    }
+}
+


### PR DESCRIPTION
- Introduced new methods in ForestStore for resolving and updating plant records, including support for branches and timestamps.
- Updated PlantCommand to handle plant assignments, unassignments, and lifecycle transitions (planned, planted, harvested, archived) with improved error handling.
- Added integration tests to validate the full lifecycle of plants, ensuring correct branch creation and commit behavior.
- Enhanced JSON output for plant details, including branches and timestamps, improving user experience in CLI interactions.
