### PR TITLE
Update CLI documentation and tests for forum selection in reconciliation process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,4 @@ TestResults/
 
 .gemini/
 gha-creds-*.json
-.git-forest/config.yaml
-.git-forest/forest.yaml
-.git-forest/lock
+.git-forest/

--- a/CLI.md
+++ b/CLI.md
@@ -197,7 +197,7 @@ gf plans remove <plan-id> [--purge-plants] [--yes]
 Default action is reconcile.
 
 ```bash
-gf plan <plan-id> [reconcile] [--update] [--only <scope>] [--dry-run] [--json]
+gf plan <plan-id> [reconcile] [--update] [--forum ai|file] [--only <scope>] [--dry-run] [--json]
 ```
 
 **Contract (important):**
@@ -209,6 +209,18 @@ gf plan <plan-id> [reconcile] [--update] [--only <scope>] [--dry-run] [--json]
   * update plan-owned fields
   * mark removed plants as `archived` (never delete unless `--purge`)
 * Never overwrites user-owned fields.
+
+**Forum selection:**
+
+* Default forum comes from `.git-forest/config.yaml`:
+
+  ```yaml
+  reconcile:
+    forum: file   # or ai
+  ```
+
+* Override per-run with `--forum ai|file` (takes precedence over config).
+* `ai` runs one agent call per planner id (multi-agent) and aggregates results deterministically.
 
 Human output:
 

--- a/docs/cli/plan.md
+++ b/docs/cli/plan.md
@@ -5,7 +5,7 @@ Manage a specific plan.
 ## Usage
 
 ```bash
-git-forest plan <plan-id> reconcile [--update] [--dry-run] [--json]
+git-forest plan <plan-id> reconcile [--update] [--forum ai|file] [--dry-run] [--json]
 ```
 
 ## Arguments
@@ -22,6 +22,7 @@ Reconcile a plan to its desired state.
 
 - `--dry-run` - Show what would be done without applying
 - `--update` - Update plan before reconciling (currently not implemented)
+- `--forum ai|file` - Override the reconciliation forum (default comes from `.git-forest/config.yaml` `reconcile.forum`, falling back to `file`)
 - `--json` - Output in JSON format (global option)
 
 ## Notes

--- a/tests/GitForest.Application.Tests/GitForest.Application.Tests.csproj
+++ b/tests/GitForest.Application.Tests/GitForest.Application.Tests.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\GitForest.Mediator\GitForest.Mediator.csproj" />
     <ProjectReference Include="..\..\src\GitForest.Application\GitForest.Application.csproj" />
     <ProjectReference Include="..\..\src\GitForest.Infrastructure.Memory\GitForest.Infrastructure.Memory.csproj" />
     <ProjectReference Include="..\..\src\GitForest.Core\GitForest.Core.csproj" />


### PR DESCRIPTION
- Enhanced CLI commands to include a `--forum` option for specifying the reconciliation forum.
- Updated related documentation to reflect changes in command usage.
- Modified tests to accommodate the new forum routing logic, including the introduction of a `ForumRouterAdapter` for better integration with the reconciliation process.
- Updated `.gitignore` to exclude all files in the `.git-forest/` directory.

## Description

<!-- Brief summary of changes -->

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Testing

<!-- Describe the tests and verification steps -->

## Checklist
- [ ] Self-review
- [ ] Tests pass
- [ ] Documentation updated
- [ ] Ready for review

## Additional Notes

<!-- Any extra context or considerations -->
